### PR TITLE
Declare this package to be obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+## This package is obsolete
+
+Since version 22.1 Emacs has built-in support for themes.  That
+implementation does not derive from the implementation provided
+by this package.  Back when this was news we referred to the new
+implementation as `deftheme` themes, as opposed to `color-theme`
+themes.
+
+This package comes with a large collection of themes.  If you
+still use it because you want to use one of those, then you can
+never-the-less migrate to the "new" theme implementation.  The
+[`color-theme-modern`][port] package ports all themes that are
+bundles with `color-theme` to the `deftheme` format.  It also
+ports a few third-party themes. Its documentation contains setup
+instructions.  Don't forget to uninstall `color-theme`.
+
+For some reason this package is in the top 93rd percentile of
+downloads from Melpa.  It is unlikely that so may people still
+use this package while being fully aware that Emacs ships with
+another implementation, but we cannot be sure.
+
+It is more likely that most of users installed this package
+because they they were under the false impression that this was
+still necessary to get Emacs to support themes.  That help this
+group of users, loading this package now shows a warning, making
+them aware of the situation.
+
+[port]: https://github.com/emacs-jp/replace-colorthemes#color-theme-modern--
+
+## Old documentation
+
+```
 Sharing your current color setup:
 
 Use `color-theme-submit'.  If you have already invested time in
@@ -84,3 +116,4 @@ Once you have printed the color-theme, you can make sure it looks
 similar in both Emacs and XEmacs by running
 `color-theme-analyze-defun' on the printed theme.  This function
 will check for missing faces for the other editor...
+```

--- a/color-theme.el
+++ b/color-theme.el
@@ -1,16 +1,16 @@
-;;; color-theme.el --- install color themes
+;;; color-theme.el --- An OBSOLETE color-theme implementation
 
 ;; Copyright (C) 1999, 2000  Jonadab the Unsightly One <jonadab@bright.net>
 ;; Copyright (C) 2000, 2001, 2002, 2003  Alex Schroeder <alex@gnu.org>
 ;; Copyright (C) 2003, 2004, 2005, 2006  Xavier Maillard <zedek@gnu.org>
 
-;; Version: 6.6.0
+;; Version: 6.6.1
 ;; Keywords: faces
 ;; Author: Jonadab the Unsightly One <jonadab@bright.net>
 ;; Maintainer: Xavier Maillard <zedek@gnu.org>
 ;; URL: http://www.emacswiki.org/cgi-bin/wiki.pl?ColorTheme
 
-;; This file is not (YET) part of GNU Emacs.
+;; This file is not part of GNU Emacs.
 
 ;; This is free software; you can redistribute it and/or modify it under
 ;; the terms of the GNU General Public License as published by the Free
@@ -29,8 +29,21 @@
 
 ;;; Commentary:
 
-;; Please read README and BUGS files for any relevant help.
-;; Contributors (not themers) should also read HACKING file.
+;; This package is obsolete.
+
+;; Since version 22.1 Emacs has built-in support for themes.  That
+;; implementation does not derive from the implementation provided
+;; by this package.  Back when this was new we referred to the new
+;; implementation as `deftheme' themes, as opposed to `color-theme'
+;; themes.
+
+;; This package comes with a large collection of themes.  If you
+;; still use it because you want to use one of those, then you can
+;; never-the-less migrate to the "new" theme implementation.  The
+;; `color-theme-modern' package ports all themes that are bundles
+;; with `color-theme' to the `deftheme' format.  It also ports a
+;; few third-party themes.  Its documentation contains setup
+;; instructions.  Don't forget to uninstall `color-theme'.
 
 ;;; Thanks
 
@@ -45,6 +58,30 @@
 
 
 ;;; Code:
+
+(defvar color-theme-obsolete t
+  "Whether to show a warning about this package being obsolete.
+This warning is shown every time the package is loaded.  If you
+want to keep using it for some reason, then you have to set this
+variable to nil *before* the library is loaded.")
+
+(when (and (>= emacs-major-version 22) color-theme-obsolete)
+  (display-warning 'color-theme "This package is obsolete.
+
+Since version 22.1 Emacs has built-in support for themes.  That
+implementation does not derive from the implementation provided
+by this package.  Back when this was new we referred to the new
+implementation as `deftheme' themes, as opposed to `color-theme'
+themes.
+
+This package comes with a large collection of themes.  If you
+still use it because you want to use one of those, then you can
+never-the-less migrate to the \"new\" theme implementation.  The
+`color-theme-modern' package ports all themes that are bundles
+with `color-theme' to the `deftheme' format.  It also ports a
+few third-party themes.  Its documentation contains setup
+instructions.  Don't forget to uninstall `color-theme'."))
+
 (eval-when-compile
   (require 'easymenu)
   (require 'reporter)


### PR DESCRIPTION
Since version 22.1, released a mere twelve years ago, Emacs has
built-in support for themes.  The old implementation provided by
this package has not seen a commit in ten years.

For some reason this package is in the top 93rd percentile of
downloads from Melpa.  It is unlikely that so may people still
use this package while being fully aware that Emacs ships with
another implementation, but we cannot be sure, so we don't
remove it from Melpa.

But we should also help all those users who have installed this
package by mistake.  For that reason why now display a warning,
which explains the situation, when it is loaded.

Also see the corresponding issue in the Melpa issue tracker: https://github.com/melpa/melpa/pull/5780.